### PR TITLE
Report you own event and changes in statemachine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,35 @@ The Swift SDK uses the [Eyevinn Player Analytics Eventsink](https://app.osaas.io
 You can read more about Eyevinn Open Source Cloud [here](https://docs.osaas.io/osaas.wiki/Home.html).
 
 ----
+
+The easiest way to get started is to add the SDK to your project using the Swift Package Manager.
+
+### Adding the SDK to you project.
+Click on `File` -> `Swift Packages` -> `Add Package Dependency...` and add the following URL: https://github.com/Eyevinn/player-analytics-client-sdk-swift
+
+### Usage
+```swift
+import VideoStreamTracker
+..
+    private let player = AVPlayer(url: URL(string: "https://path/to/video.m3u8")!)
+    private  var logger: AVPlayerEventLogger 
+
+let logger = AVPlayerEventLogger(
+    player: player,
+    eventSinkUrl: URL(string: "https://eventsink.osaas.io")!)
+
+...
+    var body: some View {
+        VStack {
+            VideoPlayer(player: player)                VideoPlayer(player:player) 
+
+            Button("Play") {
+                player.play()
+            }
+            Button("Pause") {
+                player.pause()
+            }
+        }
+        .padding()
+    }
+}

--- a/Sources/VideoStreamTracker/AnalyticsEventSender.swift
+++ b/Sources/VideoStreamTracker/AnalyticsEventSender.swift
@@ -24,6 +24,7 @@ internal enum SinkerEvent: CustomStringConvertible {
     case warning
     case paused
     case metadata
+    case report
 
     var description: String {
         switch self {
@@ -57,6 +58,8 @@ internal enum SinkerEvent: CustomStringConvertible {
             return "paused"
         case .metadata:
             return "metadata"
+        case .report:
+            return "report"
         }
     }
 }
@@ -241,6 +244,16 @@ internal final class AnalyticsEventSender {
                     playhead: playhead,
                     duration: duration,
                     payload: payload)
+    }
+
+    func sendReportEvent(playhead: Int64,
+                         duration: Int64,
+                         payload: [String: Any]?=nil) {
+        sendEvent(eventType: .report,
+                  timestamp: currentTimestamp,
+                  playhead: playhead,
+                  duration: duration,
+                  payload: payload)
     }
 
     private func sendToEventSink(event: [String: Any]) {

--- a/Sources/VideoStreamTracker/EventSinkPlayerLogger.swift
+++ b/Sources/VideoStreamTracker/EventSinkPlayerLogger.swift
@@ -66,9 +66,9 @@ public final class EventSinkPlayerLogger {
             // If you expect a JSON response, decode it.
             do {
                 let analyticResponse = try JSONDecoder().decode(AnalyticsResponse.self, from: data)
-                print("Decoded response: sessionId = \(analyticResponse.sessionId),heartbeatInterval = \(analyticResponse.heartbeatInterval)")
+                print("Response: \(analyticResponse)")
             } catch {
-                print ("Error decoding response JSON: \(error)")
+                print ("Error decoding response JSON: \(error) from data: \(data)")
             }
         }
 

--- a/Sources/VideoStreamTracker/StateMachine.swift
+++ b/Sources/VideoStreamTracker/StateMachine.swift
@@ -81,6 +81,8 @@ internal final class StateMachine {
             if nextEvent == .playing || nextEvent == .buffering {
                 return nextEvent
             }
+        case .report:
+            return currentState
         default:
             return .error
         }
@@ -99,30 +101,32 @@ internal final class StateMachine {
         case .loading:
             return nextEvent == .loaded || nextEvent == .buffering
         case .loaded:
-            return nextEvent == .playing || nextEvent == .paused || nextEvent == .buffering || nextEvent == .seeking
+            return nextEvent == .playing || nextEvent == .paused || nextEvent == .buffering || nextEvent == .seeking || nextEvent == .report
         case .playing:
-            return nextEvent == .paused || nextEvent == .buffering || nextEvent == .seeking || nextEvent == .stopped
+            return nextEvent == .paused || nextEvent == .buffering || nextEvent == .seeking || nextEvent == .stopped || nextEvent == .report
         case .heartbeat:
             return true
         case .error:
             return true
         case .stopped:
-            return nextEvent == .initEvent
+            return nextEvent == .initEvent || nextEvent == .report
         case .seeking:
-            return nextEvent == .seeked || nextEvent == .paused
+            return nextEvent == .seeked || nextEvent == .paused || nextEvent == .report
         case .seeked:
-            return nextEvent == .playing || nextEvent == .paused
+            return nextEvent == .playing || nextEvent == .paused || nextEvent == .report
         case .buffering:
-            return nextEvent == .buffered || nextEvent == .seeking || nextEvent == .stopped
+            return nextEvent == .buffered || nextEvent == .seeking || nextEvent == .stopped || nextEvent == .report
         case .buffered:
-            return nextEvent == .playing || nextEvent == .seeking || nextEvent == .paused
+            return nextEvent == .playing || nextEvent == .seeking || nextEvent == .paused || nextEvent == .report
         case .bitrateChanged:
             return true
         case .warning:
             return true
         case .paused:
-            return nextEvent == .playing || nextEvent == .buffering
+            return nextEvent == .playing || nextEvent == .buffering || nextEvent == .report
         case .metadata:
+            return true
+        case .report:
             return true
         }
     }


### PR DESCRIPTION
- Rewrite of the Read-Me to include an easy-to-use example of how to incorporate VideoStreamTracker into a Swift project.
- Added functionality for the user to "report" their own events.
- Altered the reporting of Bitratechanged to send more data.
- Changed from deprecated API:s `.AVPlayerItemNewAccessLogEntry` to `AVPlayerItem.newAccessLogEntryNotification`
- Better log-texts if there is an error during data-traffic.
- Tweaked state-machine and re-verified it with current web player sdk and the SDK-documentation.