### PR TITLE
Added Ad-handling in SGAI HLS Streams

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,12 +6,12 @@ import PackageDescription
 let package = Package(
     name: "VideoStreamTracker",
     platforms: [
-        .iOS(.v13), .tvOS(.v13)
+        .iOS(.v16), .tvOS(.v16)
     ],
     products: [
         .library(
             name: "VideoStreamTracker",
-            targets: ["VideoStreamTracker"]
+            targets: ["VideoStreamTracker", "SGAI"]
         ),
     ],
     dependencies: [], 
@@ -19,6 +19,10 @@ let package = Package(
         .target(
             name: "VideoStreamTracker",
             dependencies: []
+        ),
+        .target(
+            name: "SGAI",
+            path: "Sources/SGAI"
         ),
         .testTarget(
             name: "VideoStreamTrackerTests",

--- a/Sample/SGAIActivity_Demo/SGAIContentView.swift
+++ b/Sample/SGAIActivity_Demo/SGAIContentView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import AVKit
+import Combine
+import SGAI
+
+struct SGAIContentView: View {
+
+    @StateObject public var viewModel = SGAIPlayerViewModel(player: AVPlayer(playerItem: AVPlayerItem(url: URL(string: "https://eyevinnlab-adtracking.eyevinn-sgai-ad-proxy.auto.prod.osaas.io/loop/master.m3u8")!)))
+
+    init() {
+    }
+
+    var body: some View {
+        VStack {
+            if viewModel.isAdPlaying {
+                Text("Ad is playing")
+                Text("Duration: \(viewModel.adDuration, specifier: "%.2f") seconds")
+            } else {
+                Text("No ad playing")
+            }
+
+            if let progressEvent = viewModel.adProgressEvent {
+                Text("Ad Progress: \(progressEvent.rawValue)")
+            }
+            VideoPlayer(player: viewModel.player)
+                .frame(height: 300)
+
+            Button("Play") {
+                viewModel.player.play()
+            }
+
+            Button("Pause") {
+                viewModel.player.pause()
+            }
+        }
+        .padding()
+        .onAppear {
+            viewModel.player.play()
+        }
+    }
+}

--- a/Sources/SGAI/AdEvents.swift
+++ b/Sources/SGAI/AdEvents.swift
@@ -1,0 +1,8 @@
+
+public enum AdActivityEvent: String {
+    case started = "started"
+    case firstQuartile = "firstQuartile"
+    case midPoint = "midPoint"
+    case thirdQuartile = "thirdQuartile"
+    case complete = "complete"
+}

--- a/Sources/SGAI/SGAIPlayerActivity.swift
+++ b/Sources/SGAI/SGAIPlayerActivity.swift
@@ -1,0 +1,76 @@
+import AVKit
+import AVFoundation
+import Foundation
+
+protocol SGAIActivityDelegate: AnyObject {
+    func adStarted(_ duration: Double)
+    func adEnded()
+    func adProgress(_ progress: AdActivityEvent)
+}
+
+public final class PlayerActivityHandler {
+    weak var delegate: SGAIActivityDelegate?
+
+    private var startTime: Date?
+    private var adPlaying = false
+
+    let player:  AVPlayer
+
+    public init(player: AVPlayer) {
+        self.player = player
+
+        let observer = AVPlayerInterstitialEventMonitor(primaryPlayer: player)
+        NotificationCenter.default.addObserver(
+            forName: AVPlayerInterstitialEventMonitor.currentEventDidChangeNotification,
+            object: observer,
+            queue: OperationQueue.main) {
+                notification_ in
+                self.updateUI(observer.currentEvent)
+            }
+    }
+
+    private func updateUI(_ event: AVPlayerInterstitialEvent?) {
+        var adStatus = ""
+        var adDuration = 0.0
+        if let eventId = event?.identifier {
+            adStatus = "🔴 Ad Playing: \(event?.identifier ?? "Unknown")"
+            print("-> Ad started: \(eventId) - \(Date().description)")
+            self.adPlaying = true
+
+            if #available(iOS 18.0, *) {
+                if let duration = event?.plannedDuration {
+                    adDuration = duration.seconds
+                }
+            }
+
+            delegate?.adStarted(adDuration)
+
+            _ = Timer.scheduledTimer(withTimeInterval: adDuration / 4, repeats: false) { [self] _ in
+                if self.adPlaying {
+                    print("+---Ad Q1")
+                    delegate?.adProgress(.firstQuartile)
+                }
+            }
+            _ = Timer.scheduledTimer(withTimeInterval: adDuration / 2, repeats: false) { [self] _ in
+                if self.adPlaying {
+                    print("++--Ad Q2")
+                    self.delegate?.adProgress(.midPoint)
+                }
+            }
+            _ = Timer.scheduledTimer(withTimeInterval: (adDuration / 4) * 3, repeats: false) { [self] _ in
+                if self.adPlaying {
+                    print("+++-Ad Q3")
+                    delegate?.adProgress(.thirdQuartile)
+                }
+            }
+        } else {
+            if self.adPlaying {
+                print("<- Ad ended: - \(Date().description)")
+                self.adPlaying = false
+            }
+            adStatus = "🟢 Ad ended"
+            delegate?.adEnded()
+            delegate?.adProgress(.complete)
+        }
+    }
+}

--- a/Sources/SGAI/SGAIPlayerViewModel.swift
+++ b/Sources/SGAI/SGAIPlayerViewModel.swift
@@ -1,0 +1,78 @@
+import AVKit
+import Combine
+import Foundation
+import AVFoundation
+
+public final class SGAIPlayerViewModel: ObservableObject {
+    @Published public var isAdPlaying: Bool = false
+    @Published public var adDuration: Double = 0.0
+    @Published public var adProgressEvent: AdActivityEvent?
+
+    public let player: AVPlayer
+    private var cancellables = Set<AnyCancellable>()
+    private var timers: [Timer] = []
+
+    public init(player: AVPlayer) {
+        self.player = player
+
+        let observer = AVPlayerInterstitialEventMonitor(primaryPlayer: player)
+
+//        NotificationCenter.default.publisher(for: AVPlayerInterstitialEventMonitor.currentEventDidChangeNotification, object: observer)
+//            .receive(on: DispatchQueue.main)
+//            .sink { [weak self] _ in
+//                self?.handleInterstitialEvent(observer.currentEvent)
+//            }
+//            .store(in: &cancellables)
+        NotificationCenter.default.publisher(for: AVPlayerInterstitialEventMonitor.currentEventDidChangeNotification, object: observer)
+            .map { _ in observer.currentEvent }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] event in
+                self?.handleInterstitialEvent(event)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func handleInterstitialEvent(_ event: AVPlayerInterstitialEvent?) {
+
+        if let event = event {
+            // Ad started
+            var duration = 0.0
+            if #available(iOS 18.0, *) {
+                duration = event.plannedDuration.seconds
+            }
+            isAdPlaying = true
+            adDuration = duration
+            adProgressEvent = .started
+            scheduleAdProgressTimers(duration: duration)
+        } else {
+            // Ad ended
+            isAdPlaying = false
+            adDuration = 0.0
+            adProgressEvent = .complete
+            invalidateAdProgressTimers()
+        }
+    }
+
+    private func scheduleAdProgressTimers(duration: Double) {
+        invalidateAdProgressTimers()
+
+        let intervals: [(TimeInterval, AdActivityEvent)] = [
+            (duration / 4, .firstQuartile),
+            (duration / 2, .midPoint),
+            (3 * duration / 4, .thirdQuartile)
+        ]
+
+        for (interval, event) in intervals {
+            let timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: false) { [weak self] _ in
+                guard let self = self, self.isAdPlaying else { return }
+                self.adProgressEvent = event
+            }
+            timers.append(timer)
+        }
+    }
+
+    private func invalidateAdProgressTimers() {
+        timers.forEach { $0.invalidate() }
+        timers.removeAll()
+    }
+}


### PR DESCRIPTION
Added handlers for both UIKit and SwiftUI.
- Handle ad-interstitials in SGAI HLS streams​
- Track ad milestones (start, 25%, 50%, 75%, complete)

Changes:
- raised minimum iOS version to 16